### PR TITLE
fix: fixed missing version bump regex

### DIFF
--- a/build/gitversion.yml
+++ b/build/gitversion.yml
@@ -6,6 +6,11 @@ assembly-versioning-scheme: MajorMinorPatch
 mode: MainLine
 next-version: '' # Use git tags to set the base version.
 continuous-delivery-fallback-tag: ""
+commit-message-incrementing: Enabled
+major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
+minor-version-bump-message: "^(feat)(\\([\\w\\s-]*\\))?:"
+patch-version-bump-message: "^(build|chore|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?:"
+no-bump-message: "^(ci)(\\([\\w\\s-]*\\))?:" # You can use the "ci" type to avoid bumping the version when your changes are limited to the build or .github folders.
 branches:
   main:
     regex: ^master$|^main$


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->
This PR adds the regex that will be used to determine version incrementing.

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [X] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
The gitversion file is missing the version-bump-message regex fields.

## Impact on version
<!-- Please select one or more based on your commits. -->
The gitversion file contains the version-bump-message regex fields.

- [ ] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [ ] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [X] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [X] Documentation has been added/updated.
  - README.md was reviewed.
  - [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) was updated (if you introduced a breaking change).
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated.~~
- [X] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->